### PR TITLE
Changed C wrapper. RetroCompatibility available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,9 @@ obj:
 
 clients: src/cpp_zhtclient.cpp src/c_zhtclient.cpp
 	$(CXX) $(CPPFLAGS) $(CFLAGS) -c src/cpp_zhtclient.cpp -o obj/cpp_zhtclient.o
+	$(CXX) $(CPPFLAGS) $(CFLAGS) -c src/c_zhtclientStd.cpp -o obj/c_zhtclientStd.o
 	$(CXX) $(CPPFLAGS) $(CFLAGS) -c src/c_zhtclient.cpp -o obj/c_zhtclient.o
+
 
 obj/%.o: src/common/%.cpp obj
 	$(CXX) $(CPPFLAGS) $(CFLAGS) -c src/common/$*.cpp -o obj/$*.o

--- a/examples/c_zhtclient_main.c
+++ b/examples/c_zhtclient_main.c
@@ -3,11 +3,13 @@
 #include   <stdio.h>
 
 #include   <string.h>
-#include "c_zhtclient.h"
+#include <c_zhtclientStd.h>
 
 const int LOOKUP_SIZE = 65535;
 
 int main(int argc, char **argv) {
+
+	ZHTClient_c zhtClient;
 
 	if (argc < 4) {
 
@@ -25,7 +27,7 @@ int main(int argc, char **argv) {
 		useTCP = false;
 	}
 
-	c_zht_init(argv[1], argv[2], useTCP); //neighbor zht.cfg TCP
+	c_zht_init_std(&zhtClient, argv[1], argv[2], useTCP); //neighbor zht.cfg TCP
 
 	const char *key = "hello";
 	const char *value = "zht";
@@ -36,23 +38,23 @@ int main(int argc, char **argv) {
 	key = largeKey;
 	value = largeVal;
 
-	int iret = c_zht_insert2(key, value);
+	int iret = c_zht_insert2_std(zhtClient, key, value);
 	fprintf(stderr, "c_zht_insert, return code: %d\n", iret);
 
 	size_t n;
 	char *result = (char*) calloc(LOOKUP_SIZE, sizeof(char));
 	if (result != NULL) {
-		int lret = c_zht_lookup2(key, result, &n);
+		int lret = c_zht_lookup2_std(zhtClient, key, result, &n);
 		fprintf(stderr, "c_zht_lookup, return code: %d\n", lret);
 		fprintf(stderr, "c_zht_lookup, return value: length(%lu), %s\n", n,
 				result);
 	}
 	free(result);
 
-	int rret = c_zht_remove2(key);
+	int rret = c_zht_remove2_std(zhtClient, key);
 	fprintf(stderr, "c_zht_remove, return code: %d\n", rret);
 
-	c_zht_teardown();
+	c_zht_teardown_std(zhtClient);
 
 	return 0;
 }

--- a/inc/c_zhtclientStd.h
+++ b/inc/c_zhtclientStd.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2010-2015
+ * Datasys Lab@Illinois Inititute of Technology
+ *
+ * This file is part of ZHT library, as a c wrapper of ZHT commmon interfaces, such as initialize, insert,
+ * lookup, remove and teardown.
+ *
+ * Contributor: Tony, Xiaobingo, Corentin Debains
+ */
+
+#ifndef C_ZHTCLIENTSTD_H_
+#define C_ZHTCLIENTSTD_H_
+
+#ifdef __cplusplus
+# define ZHT_CPP(x) x
+#else
+# define ZHT_CPP(x)
+#endif
+
+#include <stddef.h>
+
+typedef void* ZHTClient_c;
+
+ZHT_CPP(extern "C" {)
+
+	/* wrapp C++ ZHTClient::initialize.
+	 * return code: 0 if succeeded, or -1 if failed.
+	 * */
+	int c_zht_init_std(ZHTClient_c * zhtClient, const char *memberConfig, const char *zhtConfig, bool tcp);
+
+	/* wrapp C++ ZHTClient::insert.
+	 * PAIR is expected to be a serializationg string with protocol-buffer-c-binding representation.
+	 * KEY: empty key not allowed, if empty, return -1, means failed.
+	 * return code: 0 if succeeded, or -1 if empty key, or -2 if failed, -98 if unrecognized operation
+	 * Untested, don't invoke it.
+	 * */
+	int c_zht_insert_std(ZHTClient_c zhtClient, const char *pair);
+
+	/* wrapp C++ ZHTClient::insert.
+	 * KEY: empty key not allowed, if empty, return -1, means failed.
+	 * VALUE: empty value ignored.
+	 * return code: 0 if succeeded, or -1 if empty key, or , -98 if unrecognized operation
+	 * */
+	int c_zht_insert2_std(ZHTClient_c zhtClient, const char *key, const char *value);
+
+	/* wrapp C++ ZHTClient::lookup.
+	 * PAIR is expected to be a serializationg string with protocol-buffer-c-binding representation.
+	 * KEY: empty key not allowed, if empty, return -1, means failed.
+	 * return code: 0 if succeeded, or -1 if empty key, or , -98 if unrecognized operation
+	 * Untested, don't invoke it.
+	 * */
+	int c_zht_lookup_std(ZHTClient_c zhtClient, const char *pair, char *result);
+
+	/* wrapp C++ ZHTClient::lookup.
+	 * KEY: empty key not allowed, if empty, return -1, means failed.
+	 * RESULT: lookup result
+	 * N: actual number of characters read.
+	 * return code: 0 if succeeded, or -1 if empty key, or , -98 if unrecognized operation
+	 * */
+	int c_zht_lookup2_std(ZHTClient_c zhtClient, const char *key, char *result, size_t *n);
+
+	/* wrapp C++ ZHTClient::remove.
+	 * PAIR is expected to be a serializationg string with protocol-buffer-c-binding representation.
+	 * KEY: empty key not allowed, if empty, return -1, means failed.
+	 * return code: 0 if succeeded, or -1 if empty key, or , -98 if unrecognized operation
+	 * Untested, don't invoke it.
+	 * */
+	int c_zht_remove_std(ZHTClient_c zhtClient, const char *pair);
+
+	/* wrapp C++ ZHTClient::remove.
+	 * KEY: empty key not allowed, if empty, return -1, means failed.
+	 * return code: 0 if succeeded, or -1 if empty key, or , -98 if unrecognized operation
+	 * */
+	int c_zht_remove2_std(ZHTClient_c zhtClient, const char *key);
+
+	/* wrapp C++ ZHTClient::teardown.
+	 * return code: 0 if succeeded, or -1 if failed.
+	 * */
+	int c_zht_teardown_std(ZHTClient_c zhtClient);
+
+ZHT_CPP	(})
+
+#endif

--- a/src/c_zhtclient.cpp
+++ b/src/c_zhtclient.cpp
@@ -1,146 +1,45 @@
-#include "c_zhtclient.h"
-#include "cpp_zhtclient.h"
-#include <string.h>
+#include "../inc/c_zhtclient.h"
+#include "../inc/c_zhtclientStd.h"
 
-ZHTClient zhtClient;
-bool TCP = false;
-
-/*
- * to be removed.
- */
-void test_proto_buffer(const char *key, const char *value) {
-	Package package;
-	package.set_virtualpath(key); //as key
-	package.set_isdir(true);
-	package.set_replicano(5);
-	package.set_operation(3); //1 for look up, 2 for remove, 3 for insert
-	package.set_realfullpath(value);
-
-	fprintf(stderr, "package virtualpath is: %s\n",
-			package.virtualpath().c_str());
-
-	const char * realfullpath = package.realfullpath().c_str();
-	fprintf(stderr, "package realfullpath is: %s\n", realfullpath);
-
-	string str = package.SerializeAsString();
-	int len = strlen(str.c_str());
-
-	Package package2;
-	package2.ParseFromString(str);
-	string str2 = package2.SerializeAsString();
-
-	fprintf(stderr, "package2 virtualpath is: %s\n",
-			package2.virtualpath().c_str());
-
-	const char *realfullpath2 = package2.realfullpath().c_str();
-	fprintf(stderr, "package2 realfullpath is: %s\n", realfullpath2);
-
-}
+ZHTClient_c zhtClient;
 
 int c_zht_init(const char *memberConfig, const char *zhtConfig, bool tcp) {
-
-	string zhtStr(zhtConfig);
-	string memberStr(memberConfig);
-
-	if (zhtClient.initialize(zhtStr, memberStr, tcp) != 0) {
-		printf("Crap! ZHTClient initialization failed, program exits.");
-
-		return -1;
-	}
-
-	return 0;
+	
+	return c_zht_init_std(&zhtClient, memberConfig, zhtConfig, tcp);
 }
 
 int c_zht_insert(const char *pair) {
 
-	string str(pair);
-
-	return zhtClient.insert(str);
+	return c_zht_insert_std(zhtClient, pair);
 }
 
 int c_zht_insert2(const char *key, const char *value) {
 
-	string keyStr(key);
-	string valueStr(value);
-
-	if (keyStr.empty()) //empty key not allowed.
-		return -1;
-
-	Package package;
-	package.set_virtualpath(keyStr); //as key
-	package.set_isdir(true);
-	package.set_replicano(5);
-	package.set_operation(3); //1 for look up, 2 for remove, 3 for insert
-	if (!valueStr.empty())
-		package.set_realfullpath(valueStr);
-
-	return zhtClient.insert(package.SerializeAsString());
-
+	return c_zht_insert2_std(zhtClient, key, value);
 }
 
 int c_zht_lookup(const char *pair, char *result) {
 
-	string pkg(pair);
-	string returnStr;
-
-	int ret = zhtClient.lookup(pkg, returnStr);
-
-	char *chars = new char[returnStr.size() + 1];
-	strcpy(chars, returnStr.c_str());
-
-	result = chars;
-
-	return ret;
+	return c_zht_lookup_std(zhtClient, pair, result);
 }
 
 int c_zht_lookup2(const char *key, char *result, size_t *n) {
 
-	string keyStr(key);
-	string resultStr;
-
-	if (keyStr.empty()) //empty key not allowed.
-		return -1;
-
-	Package package;
-	package.set_virtualpath(keyStr); //as key
-	package.set_isdir(true);
-	package.set_replicano(5);
-	package.set_operation(1); //1 for look up, 2 for remove, 3 for insert
-
-	int ret = zhtClient.lookup(package.SerializeAsString(), resultStr);
-
-	Package package2;
-	package2.ParseFromString(resultStr);
-	string strRealfullpath = package2.realfullpath();
-	strncpy(result, strRealfullpath.c_str(), strlen(result));
-	*n = strRealfullpath.size();
-
-	return ret;
+	return c_zht_lookup2_std(zhtClient, key, result, n);
 }
 
 int c_zht_remove(const char *pair) {
 
-	string str(pair);
-
-	return zhtClient.remove(str);
+	return c_zht_remove_std(zhtClient, pair);
 }
 
 int c_zht_remove2(const char *key) {
 
-	string keyStr(key);
-
-	if (keyStr.empty()) //empty key not allowed.
-		return -1;
-
-	Package package;
-	package.set_virtualpath(keyStr);
-	package.set_operation(2); //1 for look up, 2 for remove, 3 for insert
-
-	return zhtClient.remove(package.SerializeAsString());
+	return c_zht_remove2_std(zhtClient, key);
 }
 
 int c_zht_teardown() {
 
-	return zhtClient.tearDownTCP();
+	return c_zht_teardown_std(zhtClient);
 }
 

--- a/src/c_zhtclientStd.cpp
+++ b/src/c_zhtclientStd.cpp
@@ -1,0 +1,163 @@
+#include "../inc/c_zhtclientStd.h"
+#include "../inc/cpp_zhtclient.h"
+#include <string.h>
+
+bool TCP = false;
+
+/*
+ * to be removed.
+ */
+void test_proto_buffer(const char *key, const char *value) {
+	Package package;
+	package.set_virtualpath(key); //as key
+	package.set_isdir(true);
+	package.set_replicano(5);
+	package.set_operation(3); //1 for look up, 2 for remove, 3 for insert
+	package.set_realfullpath(value);
+
+	fprintf(stderr, "package virtualpath is: %s\n",
+			package.virtualpath().c_str());
+
+	const char * realfullpath = package.realfullpath().c_str();
+	fprintf(stderr, "package realfullpath is: %s\n", realfullpath);
+
+	string str = package.SerializeAsString();
+	int len = strlen(str.c_str());
+
+	Package package2;
+	package2.ParseFromString(str);
+	string str2 = package2.SerializeAsString();
+
+	fprintf(stderr, "package2 virtualpath is: %s\n",
+			package2.virtualpath().c_str());
+
+	const char *realfullpath2 = package2.realfullpath().c_str();
+	fprintf(stderr, "package2 realfullpath is: %s\n", realfullpath2);
+
+}
+
+int c_zht_init_std(ZHTClient_c * zhtClient, const char *memberConfig, const char *zhtConfig, bool tcp) {
+
+	ZHTClient * zhtcppClient = new ZHTClient();
+	
+	string zhtStr(zhtConfig);
+	string memberStr(memberConfig);
+
+	if (zhtcppClient->initialize(zhtStr, memberStr, tcp) != 0) {
+		printf("Crap! ZHTClient initialization failed, program exits.");
+
+		return -1;
+	}
+	
+	*zhtClient = (ZHTClient_c) zhtcppClient;
+
+	return 0;
+}
+
+int c_zht_insert_std(ZHTClient_c zhtClient, const char *pair) {
+
+	ZHTClient * zhtcppClient = (ZHTClient *) zhtClient;
+
+	string str(pair);
+
+	return zhtcppClient->insert(str);
+}
+
+int c_zht_insert2_std(ZHTClient_c zhtClient, const char *key, const char *value) {
+
+	ZHTClient * zhtcppClient = (ZHTClient *) zhtClient;
+
+	string keyStr(key);
+	string valueStr(value);
+
+	if (keyStr.empty()) //empty key not allowed.
+		return -1;
+
+	Package package;
+	package.set_virtualpath(keyStr); //as key
+	package.set_isdir(true);
+	package.set_replicano(5);
+	package.set_operation(3); //1 for look up, 2 for remove, 3 for insert
+	if (!valueStr.empty())
+		package.set_realfullpath(valueStr);
+
+	return zhtcppClient->insert(package.SerializeAsString());
+
+}
+
+int c_zht_lookup_std(ZHTClient_c zhtClient, const char *pair, char *result) {
+
+	ZHTClient * zhtcppClient = (ZHTClient *) zhtClient;
+
+	string pkg(pair);
+	string returnStr;
+
+	int ret = zhtcppClient->lookup(pkg, returnStr);
+
+	char *chars = new char[returnStr.size() + 1];
+	strcpy(chars, returnStr.c_str());
+
+	result = chars;
+
+	return ret;
+}
+
+int c_zht_lookup2_std(ZHTClient_c zhtClient, const char *key, char *result, size_t *n) {
+
+	ZHTClient * zhtcppClient = (ZHTClient *) zhtClient;
+
+	string keyStr(key);
+	string resultStr;
+
+	if (keyStr.empty()) //empty key not allowed.
+		return -1;
+
+	Package package;
+	package.set_virtualpath(keyStr); //as key
+	package.set_isdir(true);
+	package.set_replicano(5);
+	package.set_operation(1); //1 for look up, 2 for remove, 3 for insert
+
+	int ret = zhtcppClient->lookup(package.SerializeAsString(), resultStr);
+
+	Package package2;
+	package2.ParseFromString(resultStr);
+	string strRealfullpath = package2.realfullpath();
+	strncpy(result, strRealfullpath.c_str(), strlen(result));
+	*n = strRealfullpath.size();
+
+	return ret;
+}
+
+int c_zht_remove_std(ZHTClient_c zhtClient, const char *pair) {
+
+	ZHTClient * zhtcppClient = (ZHTClient *) zhtClient;
+
+	string str(pair);
+
+	return zhtcppClient->remove(str);
+}
+
+int c_zht_remove2_std(ZHTClient_c zhtClient, const char *key) {
+
+	ZHTClient * zhtcppClient = (ZHTClient *) zhtClient;
+
+	string keyStr(key);
+
+	if (keyStr.empty()) //empty key not allowed.
+		return -1;
+
+	Package package;
+	package.set_virtualpath(keyStr);
+	package.set_operation(2); //1 for look up, 2 for remove, 3 for insert
+
+	return zhtcppClient->remove(package.SerializeAsString());
+}
+
+int c_zht_teardown_std(ZHTClient_c zhtClient) {
+
+	ZHTClient * zhtcppClient = (ZHTClient *) zhtClient;
+
+	return zhtcppClient->tearDownTCP();
+}
+


### PR DESCRIPTION
I updated the Client C wrapper to make it more customizable (possibility to define our own Client variable and play with it!)

The retrocompatibility works perfectly. No need to modify your programs which are using the old version.
