### PR TITLE
Added install-target to Makefile for both src and src-test

### DIFF
--- a/src-test/Makefile
+++ b/src-test/Makefile
@@ -92,4 +92,7 @@ mpi:
 		
 	mpicxx ZHTServer.cpp mpi_server.cpp ProxyStubFactory.cpp proxy_stub.cpp mpi_proxy_stub.cpp Util.cpp Env.cpp mq_proxy_stub.cpp ipc_plus.cpp ConfHandler.cpp ConfEntry.cpp StrTokenizer.cpp HTWorker.cpp Const.cpp novoht.cpp meta.pb.cc zpack.pb.cc lock_guard.cpp $(MPIFLAGS) $(MPILIBFLAGS) -o zht-mpiserver
 
-	
+install: all
+	mkdir -p /usr/local/include/zht
+	cp *.h /usr/local/include/zht
+	cp libzht.a /usr/local/lib

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,4 +92,7 @@ mpi:
 		
 	mpicxx ZHTServer.cpp mpi_server.cpp ProxyStubFactory.cpp proxy_stub.cpp mpi_proxy_stub.cpp Util.cpp Env.cpp mq_proxy_stub.cpp ipc_plus.cpp ConfHandler.cpp ConfEntry.cpp StrTokenizer.cpp HTWorker.cpp Const.cpp novoht.cpp meta.pb.cc zpack.pb.cc lock_guard.cpp $(MPIFLAGS) $(MPILIBFLAGS) -o zht-mpiserver
 
-	
+install: all
+	mkdir -p /usr/local/include/zht
+	cp *.h /usr/local/include/zht
+	cp libzht.a /usr/local/lib


### PR DESCRIPTION
Hi, 

I have added an install-target for both the src and the src-test Makefile, that allows to install the library and the headers into /usr/local:
- The library will go to /usr/local/lib
- The headers will go to /usr/local/include/zht

Best wishes,
Steffen
